### PR TITLE
Directly Debug for server.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.DS_Store
+package-lock.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,14 +5,16 @@
             "name": "Launch",
             "type": "node",
             "request": "launch",
-            "program": "${workspaceRoot}/index.js",
+            "program": "${workspaceRoot}/server.js",
             "stopOnEntry": false,
             "args": [],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": null,
             "runtimeExecutable": null,
             "runtimeArgs": [
-                "--nolazy"
+                "--nolazy",
+                "--require",
+                "babel-register"
             ],
             "env": {
                 "NODE_ENV": "development"

--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-require('babel-register');
-require('./server.js');

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/katopz/vscode-debug-nodejs-es6.git"
+    "url": "git+https://github.com/horihiro/vscode-debug-nodejs-es6.git"
   },
-  "author": "katopz",
+  "author": "katopz / horihiro",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/katopz/vscode-debug-nodejs-es6/issues"
+    "url": "https://github.com/horihiro/vscode-debug-nodejs-es6/issues"
   },
-  "homepage": "https://github.com/katopz/vscode-debug-nodejs-es6#readme",
+  "homepage": "https://github.com/horihiro/vscode-debug-nodejs-es6#readme",
   "devDependencies": {
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   },
   "homepage": "https://github.com/katopz/vscode-debug-nodejs-es6#readme",
   "devDependencies": {
-    "babel-preset-es2015": "^6.18.0",
-    "babel-register": "^6.18.0"
+    "babel-preset-env": "^1.6.1",
+    "babel-register": "^6.26.0"
   },
   "babel": {
     "presets": [
-      "es2015"
+      "env"
     ],
     "sourceMaps": true,
     "retainLines": true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-debug-nodejs-es6",
   "version": "1.0.0",
   "description": "How to debug ES6 NodeJS with VSCode",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/horihiro/vscode-debug-nodejs-es6.git"
+    "url": "git+https://github.com/katopz/vscode-debug-nodejs-es6.git"
   },
-  "author": "katopz / horihiro",
+  "author": "katopz",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/horihiro/vscode-debug-nodejs-es6/issues"
+    "url": "https://github.com/katopz/vscode-debug-nodejs-es6/issues"
   },
-  "homepage": "https://github.com/horihiro/vscode-debug-nodejs-es6#readme",
+  "homepage": "https://github.com/katopz/vscode-debug-nodejs-es6#readme",
   "devDependencies": {
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0"


### PR DESCRIPTION
I fix for directly debugging server.js with vscode using `--require` option and remove index.js.

And `babel-preset-env` is used instead of `babel-preset-2015`.